### PR TITLE
Update README file to use project name `drf-link-header-pagination` for pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This pagination style accepts a single page number in the request query paramete
 Install using ``pip``:
 
 ```bash
-$ pip install djangorestframework-link-header-pagination
+$ pip install drf-link-header-pagination
 ```
 
 ## Setup


### PR DESCRIPTION
When I look at pypi repository, `djangorestframework-link-header-pagination` project version is `0.1.1`, and `drf-link-header-pagination` projet version is `0.2.0`, so I guess you changed project name oneday.